### PR TITLE
Fixes UPLOAD PICTURE button issue

### DIFF
--- a/systers_portal/static/js/choose_profile_pic.js
+++ b/systers_portal/static/js/choose_profile_pic.js
@@ -1,7 +1,7 @@
 // Altered content for the form loaded by crispy forms
-var htmlInnerContent="<label for='id_profile_picture' \n" + 
+var htmlInnerContent="<label for='id_profile_picture' \n" +
 "class='control-label'>Profile picture</label><br>\n" +
-"<button id='upload_pic' class='btn btn-default'>\n" +
+"<button id='upload_pic' class='btn btn-default' type='button'>\n" +
 "UPLOAD PICTURE</button><strong id='file_name_display'>\n" +
  "</strong><div class='controls'> <input name='profile_picture'\n" +
   "class='clearablefileinput' id='id_profile_picture' type='file'\n" +


### PR DESCRIPTION
### Description
Required changes are made to resolve the issue that users face when they hit the Upload Picture button as described in issue #462. Users can now edit their details and save them without getting redirected back to view_profile page. 

Fixes #462 

### Type of Change:
- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested locally as shown.
![profileedit_prrec](https://user-images.githubusercontent.com/33948877/53438292-9c2e6d00-3a25-11e9-9470-4d155324e2e5.gif)


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
