### PR TITLE
Broken Links In README Fixed, fixes #495

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ and with other communities.
 
 Website: http://portal.systers.org
 
-Project page: http://systers.github.io/portal/
+Project page: https://anitab-org.github.io/portal/
 
 
-If you are an Outreachy Applicant, start with reading [this](https://github.com/systers/ossprojects/wiki/Systers-Portal) for meetup features, please go through [this](https://github.com/systers/ossprojects/wiki/Meetup-Features).
+If you are interested in learning more about this project, start with reading [Portal GitHub Wiki](https://github.com/anitab-org/portal/wiki).
 
 Setup for developers (Unix)
 ---------------------------


### PR DESCRIPTION
### Description
Links to the project page and wiki page in README updated.

Fixes #495 

### Type of Change:
**Delete irrelevant options.**

- Documentation


### How Has This Been Tested?
I tested the updated links and all of them are redirecting to the correct page.


### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation 

